### PR TITLE
Update design to Apple style

### DIFF
--- a/codex-test/src/app/app.component.html
+++ b/codex-test/src/app/app.component.html
@@ -1,7 +1,11 @@
-<h1>Hello, {{ title }}</h1>
-<nav>
-  <a routerLink="/" routerLinkActive="active" [routerLinkActiveOptions]="{ exact: true }">Home</a> |
-  <a routerLink="/about" routerLinkActive="active">About</a> |
-  <a routerLink="/contact" routerLinkActive="active">Contact</a>
-</nav>
-<router-outlet></router-outlet>
+<header>
+  <h1>{{ title }}</h1>
+  <nav>
+    <a routerLink="/" routerLinkActive="active" [routerLinkActiveOptions]="{ exact: true }">Home</a>
+    <a routerLink="/about" routerLinkActive="active">About</a>
+    <a routerLink="/contact" routerLinkActive="active">Contact</a>
+  </nav>
+</header>
+<main>
+  <router-outlet></router-outlet>
+</main>

--- a/codex-test/src/app/app.component.scss
+++ b/codex-test/src/app/app.component.scss
@@ -1,10 +1,38 @@
-nav {
-  margin-bottom: 1rem;
+
+:host {
+  display: block;
+  min-height: 100vh;
+  background-color: #f5f5f7;
 }
+
+header {
+  text-align: center;
+  padding: 2rem 1rem 1rem;
+}
+
+header h1 {
+  margin: 0 0 1rem;
+  font-size: 2rem;
+  font-weight: 600;
+}
+
+nav {
+  display: flex;
+  justify-content: center;
+  gap: 1.5rem;
+}
+
 nav a {
   text-decoration: none;
-  padding: 0 0.5rem;
+  color: #1d1d1f;
+  font-weight: 500;
+  padding: 0.25rem 0;
 }
+
 nav a.active {
-  font-weight: bold;
+  border-bottom: 2px solid #0071e3;
+}
+
+main {
+  padding: 2rem 1rem;
 }

--- a/codex-test/src/app/app.component.spec.ts
+++ b/codex-test/src/app/app.component.spec.ts
@@ -24,6 +24,6 @@ describe('AppComponent', () => {
     const fixture = TestBed.createComponent(AppComponent);
     fixture.detectChanges();
     const compiled = fixture.nativeElement as HTMLElement;
-    expect(compiled.querySelector('h1')?.textContent).toContain('Hello, codex-test');
+    expect(compiled.querySelector('h1')?.textContent).toContain('codex-test');
   });
 });

--- a/codex-test/src/app/pages/home/home.component.html
+++ b/codex-test/src/app/pages/home/home.component.html
@@ -1,1 +1,4 @@
-<p>Home page works!</p>
+<section class="hero">
+  <h2>Bienvenue sur CodexTest</h2>
+  <p class="subtitle">Une expérience épurée inspirée d'Apple.</p>
+</section>

--- a/codex-test/src/app/pages/home/home.component.scss
+++ b/codex-test/src/app/pages/home/home.component.scss
@@ -1,0 +1,14 @@
+section.hero {
+  text-align: center;
+  padding: 4rem 1rem;
+}
+
+section.hero h2 {
+  font-size: 2.5rem;
+  margin: 0 0 1rem;
+}
+
+section.hero .subtitle {
+  color: #6e6e73;
+  font-size: 1.2rem;
+}

--- a/codex-test/src/styles.scss
+++ b/codex-test/src/styles.scss
@@ -1,1 +1,8 @@
-/* You can add global styles to this file, and also import other style files */
+/* Basic global styling inspired by Apple's clean look */
+body {
+  margin: 0;
+  background-color: #f5f5f7;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu,
+    Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+  color: #1d1d1f;
+}


### PR DESCRIPTION
## Summary
- apply a minimal Apple-like theme
- update home page with hero text
- adjust unit test to match new markup

## Testing
- `npx ng test --browsers=ChromeHeadless --watch=false` *(fails: No ChromeHeadless binary)*

------
https://chatgpt.com/codex/tasks/task_e_6851693f3e18832e98a540dac346c63b